### PR TITLE
usuniecie linii z nazwa openFile1

### DIFF
--- a/WindowsFormsApp1/Form1.Designer.cs
+++ b/WindowsFormsApp1/Form1.Designer.cs
@@ -99,10 +99,6 @@
             this.pictureBox2.TabIndex = 2;
             this.pictureBox2.TabStop = false;
             // 
-            // openFileDialog1
-            // 
-            this.openFileDialog1.FileName = "openFileDialog1";
-            // 
             // button1
             // 
             this.button1.Location = new System.Drawing.Point(965, 729);


### PR DESCRIPTION
Usunięcie nazwy kontrolki openFileDialog1, żeby nie wyświetlała się w polu nazwy pliku po otworzeniu okna dodawania